### PR TITLE
Fix: returns None if token not exists

### DIFF
--- a/src/non_fungible_token_clone/core/core_impl.rs
+++ b/src/non_fungible_token_clone/core/core_impl.rs
@@ -55,6 +55,10 @@ impl NonFungibleTokenClone {
             panic!("Token metadata extension must be used to clone.")
         }
 
+        if self.nft.token_metadata_by_id.as_ref().unwrap().get(&clone_from_id).is_none() {
+            panic!("The token to be cloned from the parent must have metadata.")
+        }
+
         let token = self.nft.internal_mint_with_refund(
             token_id.clone(),
             token_owner_id,

--- a/src/non_fungible_token_clone/core/core_impl.rs
+++ b/src/non_fungible_token_clone/core/core_impl.rs
@@ -124,20 +124,26 @@ impl NonFungibleTokenCore for NonFungibleTokenClone {
     }
 
     fn nft_token(&self, token_id: TokenId) -> Option<Token> {
-        let unwrap_token = self
+        let token: Option<Token>= self
             .nft
-            .nft_token(token_id.clone())
-            .unwrap_or_else(|| env::panic_str("Token does not exist"));
+            .nft_token(token_id.clone());
+
+        if token.is_none() {
+            return None;
+        }
+
+        let unwrap_token = token.unwrap();
+
         let clone_from = self
             .nft_clone_from_id
             .get(&token_id)
             .unwrap_or_else(|| token_id);
+
         let metadata = self
             .nft
             .token_metadata_by_id
-            .as_ref()
-            .unwrap_or_else(|| env::panic_str("Token not found within metadata"))
-            .get(&clone_from);
+            .as_ref().unwrap().get(&clone_from);
+
         Some(Token {
             token_id: unwrap_token.token_id,
             owner_id: unwrap_token.owner_id,

--- a/src/non_fungible_token_clone/enumeration/enumeration_impl.rs
+++ b/src/non_fungible_token_clone/enumeration/enumeration_impl.rs
@@ -238,7 +238,6 @@ mod tests {
         contract_enum.nft_supply_for_owner(accounts(1));
     }
 
-    #[should_panic(expected = "Token does not exist")]
     #[test]
     fn test_token_not_found() {
         let mut ctx = VMContextBuilder::new();
@@ -264,6 +263,6 @@ mod tests {
             StorageKey::OriginClone,
             StorageKey::Clone,
         );
-        contract.nft_token("999".to_string());
+        assert!(contract.nft_token("999".to_string()) == None, "Token should be None");
     }
 }

--- a/src/non_fungible_token_clone/enumeration/enumeration_impl.rs
+++ b/src/non_fungible_token_clone/enumeration/enumeration_impl.rs
@@ -263,6 +263,77 @@ mod tests {
             StorageKey::OriginClone,
             StorageKey::Clone,
         );
-        assert!(contract.nft_token("999".to_string()) == None, "Token should be None");
+        assert!(
+            contract.nft_token("999".to_string()) == None,
+            "Token should be None"
+        );
+    }
+
+    #[should_panic(expected = "The token to be cloned from the parent must have metadata.")]
+    #[test]
+    fn test_clone_from_another_clone() {
+        let mut ctx = VMContextBuilder::new();
+        ctx.context.attached_deposit = 7000000000000000000000;
+        testing_env!(ctx.context);
+
+        #[derive(BorshStorageKey, BorshSerialize)]
+        pub enum StorageKey {
+            NonFungibleToken,
+            TokenMetadata,
+            Enumeration,
+            Approval,
+            OriginClone,
+            Clone,
+        }
+
+        let mut contract = NonFungibleTokenClone::new(
+            StorageKey::NonFungibleToken,
+            env::current_account_id(),
+            Some(StorageKey::TokenMetadata),
+            Some(StorageKey::Enumeration),
+            Some(StorageKey::Approval),
+            StorageKey::OriginClone,
+            StorageKey::Clone,
+        );
+
+        assert!(
+            contract.nft_token("999".to_string()) == None,
+            "Token should be None"
+        );
+
+        let clone_from_id: TokenId = "1".into();
+        let parent_metadata: TokenMetadata = TokenMetadata {
+            title: Some("title".into()),
+            description: Some("description".into()),
+            media: None,
+            media_hash: None,
+            copies: None,
+            issued_at: None,
+            expires_at: None,
+            starts_at: None,
+            updated_at: None,
+            extra: None,
+            reference: None,
+            reference_hash: None,
+        };
+
+        contract.nft.internal_mint(
+            clone_from_id.clone(),
+            accounts(0),
+            Some(parent_metadata.clone()),
+        );
+
+        contract.internal_clone_mint(
+            "2".into(),
+            clone_from_id,
+            accounts(0)
+        );
+
+        // Clone from another clone
+        contract.internal_clone_mint(
+            "3".into(),
+            "2".into(),
+            accounts(0)
+        );
     }
 }


### PR DESCRIPTION
# Issue #3 
- Return None if the token not exists.
- Before cloning check, if the genesis has metadata.